### PR TITLE
Add instructions for running Nerves on QEMU

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,34 @@ This is the base Nerves System configuration for [QEMU](http://wiki.qemu.org/Mai
 
 This is the start of a QEMU configuration. Help is needed to make Ethernet
 work so that it's possible to `remsh` into the image. If you know how to
-make QEMU do this on Linux and/or OSX please let us know!
+make QEMU do this on Linux and/or OS X please let us know!
+
+## Usage
+
+Here's an example of how to run the Nerves [getting started
+example](https://hexdocs.pm/nerves/getting-started.html) on QEMU:
+
+    $ mix nerves.new hello_nerves --target qemu_arm
+
+    $ cd hello_nerves && mix deps.get && mix firmware
+
+    $ fwup -a -d _images/qemu_arm/hello_nerves.img -i _images/qemu_arm/hello_nerves.fw -t complete
+
+    $ qemu-system-arm -M vexpress-a9 -smp 1 -m 256                         \
+        -kernel _build/qemu_arm/dev/nerves/system/images/zImage            \
+        -dtb _build/qemu_arm/dev/nerves/system/images/vexpress-v2p-ca9.dtb \
+        -drive file=_images/qemu_arm/hello_nerves.img,if=sd,format=raw     \
+        -append "console=ttyAMA0,115200 root=/dev/mmcblk0p2"               \
+        -serial stdio -net nic,model=lan9118 -net user
+
+If all goes well, you will shortly see the QEMU graphical monitor console
+pop up, displaying the Nerves logo in the top left corner and running an
+interactive Elixir shell (IEx).
+
+For network connectivity, try running the Nerves
+[hello_network](https://github.com/nerves-project/nerves-examples/tree/master/hello_network)
+example and configuring the QEMU command line `-net` directives for your
+environment.
 
 ## Installation
 


### PR DESCRIPTION
As previously discussed with @fhunleth on Slack, I and my colleague @mikegogulski are in the process of figuring out how to run Nerves firmware on QEMU.

This pull request adds basic instructions to the README for booting up a trivial Nerves project, from scratch, on QEMU. The instructions are based on those for Buildroot's [arm-vexpress](https://github.com/buildroot/buildroot/tree/master/board/qemu/arm-vexpress) target (from a tip by @fhunleth) and have been successfully tested with QEMU 2.6 on both OS X 10.11 as well as Ubuntu 16.04.

More pull requests to follow as we proceed to figure out networking support and to also test out the emulated `raspi2` machine type in [QEMU 2.6+](https://wiki.qemu.org/ChangeLog/2.6).

[![Screenshot](https://i.imgur.com/9JEMMGE.jpg)](http://imgur.com/9JEMMGE)
