### PR TITLE
Add a how-to for networking on OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ If all goes well, you will shortly see the QEMU graphical monitor console
 pop up, displaying the Nerves logo in the top left corner and running an
 interactive Elixir shell (IEx):
 
-[![Screenshot](https://i.imgur.com/9JEMMGE.jpg)](http://imgur.com/9JEMMGE)
+[![Screenshot](https://i.imgur.com/9JEMMGEh.jpg)](https://i.imgur.com/9JEMMGE.jpg)
 
 ## Networking
 
@@ -101,6 +101,8 @@ Configure your Mac such that packets arriving from the `bridge1` interface
 are routed correctly, and enable NAT such that response packets find their
 way back:
 
+    $ curl -OL https://github.com/nerves-project/nerves_system_qemu_arm/raw/develop/qemu-pf.conf
+
     $ sudo sysctl -w net.inet.ip.forwarding=1
     $ sudo pfctl -F all              # flush existing rules
     $ sudo pfctl -f qemu-pf.conf     # load NAT rules for bridge1
@@ -121,6 +123,9 @@ example:
     $ git clone https://github.com/nerves-project/nerves-examples.git
 
     $ cd nerves-examples/hello_network
+
+    $ curl -OL https://github.com/nerves-project/nerves_system_qemu_arm/raw/develop/qemu-ifup.sh
+    $ curl -OL https://github.com/nerves-project/nerves_system_qemu_arm/raw/develop/qemu-ifdown.sh
 
     $ NERVES_TARGET=qemu_arm mix deps.get
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ make QEMU do this on Linux and/or OS X please let us know!
 
 ### Hello, Nerves!
 
-Here's a baseline example of how to run the Nerves [getting started
+Here follows a baseline example of how to run the Nerves [getting started
 example](https://hexdocs.pm/nerves/getting-started.html) on QEMU:
 
     $ mix nerves.new hello_nerves --target qemu_arm
@@ -45,7 +45,9 @@ example](https://hexdocs.pm/nerves/getting-started.html) on QEMU:
 
 If all goes well, you will shortly see the QEMU graphical monitor console
 pop up, displaying the Nerves logo in the top left corner and running an
-interactive Elixir shell (IEx).
+interactive Elixir shell (IEx):
+
+[![Screenshot](https://i.imgur.com/9JEMMGE.jpg)](http://imgur.com/9JEMMGE)
 
 ## Networking
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ This is the start of a QEMU configuration. Help is needed to make Ethernet
 work so that it's possible to `remsh` into the image. If you know how to
 make QEMU do this on Linux and/or OS X please let us know!
 
-## Usage
+## Booting
 
-Here's an example of how to run the Nerves [getting started
+### Hello, Nerves!
+
+Here's a baseline example of how to run the Nerves [getting started
 example](https://hexdocs.pm/nerves/getting-started.html) on QEMU:
 
     $ mix nerves.new hello_nerves --target qemu_arm
@@ -38,17 +40,107 @@ example](https://hexdocs.pm/nerves/getting-started.html) on QEMU:
         -kernel _build/qemu_arm/dev/nerves/system/images/zImage            \
         -dtb _build/qemu_arm/dev/nerves/system/images/vexpress-v2p-ca9.dtb \
         -drive file=_images/qemu_arm/hello_nerves.img,if=sd,format=raw     \
-        -append "console=ttyAMA0,115200 root=/dev/mmcblk0p2"               \
-        -serial stdio -net nic,model=lan9118 -net user
+        -append "console=ttyAMA0,115200 root=/dev/mmcblk0p2" -serial stdio \
+        -net none
 
 If all goes well, you will shortly see the QEMU graphical monitor console
 pop up, displaying the Nerves logo in the top left corner and running an
 interactive Elixir shell (IEx).
 
-For network connectivity, try running the Nerves
+## Networking
+
+To enable networking with Nerves on QEMU, you will need to do more elaborate
+setup, and you will require superuser (i.e., root) privileges.
+
+### Networking on OS X
+
+**Note:** These instructions are up to date as of OS X El Capitan 10.11.6.
+In the following, `en0` is assumed to be your primary physical OS X network
+interface (Ethernet or Wi-Fi), and `bridge1` a virtual bridge interface that
+we'll create for use with QEMU. In case those interface names don't work for
+you, adjust all instructions accordingly. Similarly, the subnet
+192.168.78.1/24 is an arbitrary choice for example purposes, change it as
+you please.
+
+*Kudos to [@salessandri](https://github.com/salessandri) for his guide to
+[setting up a NAT network for QEMU on OS
+X](https://blog.san-ss.com.ar/2016/04/setup-nat-network-for-qemu-macosx)
+on which the following is based.*
+
+#### 1. TunTap drivers
+
+Install the [TunTap](http://tuntaposx.sourceforge.net/) kernel extensions
+either manually from SourceForge or directly with [Homebrew](http://brew.sh/):
+
+    $ sudo brew cask install tuntap
+
+Note that `sudo` is required in the above, as these kernel extensions will
+get installed into the system paths `/Library/Extensions/{tap,tun}.kext`.
+
+Now load the `tun`/`tap` kernel extensions, and ensure that they will get
+automatically loaded on startup when your machine is rebooted in the future:
+
+    $ sudo launchctl load /Library/LaunchDaemons/net.sf.tuntaposx.tap.plist
+    $ sudo launchctl load /Library/LaunchDaemons/net.sf.tuntaposx.tun.plist
+
+#### 2. Bridge interface
+
+Create and configure a virtual network bridge interface `bridge1` for QEMU,
+connecting the bridge to your primary physical network interface `en0` and
+configuring it to use its own /24 subnet:
+
+    $ sudo ifconfig bridge1 create
+    $ sudo ifconfig bridge1 addm en0
+    $ sudo ifconfig bridge1 192.168.78.1/24   # 78 = ?N
+
+#### 3. Packet forwarding and NAT
+
+Configure your Mac such that packets arriving from the `bridge1` interface
+are routed correctly, and enable NAT such that response packets find their
+way back:
+
+    $ sudo sysctl -w net.inet.ip.forwarding=1
+    $ sudo pfctl -F all              # flush existing rules
+    $ sudo pfctl -f qemu-pf.conf     # load NAT rules for bridge1
+
+(Note that `pfctl -F all` also flushes any other rules, unrelated to QEMU.
+If you know how to improve this, please contribute a README improvement.)
+
+#### 4. DHCP configuration
+
+**TODO**
+
+### Hello, Network!
+
+Now you're ready to proceed to building and booting up the Nerves
 [hello_network](https://github.com/nerves-project/nerves-examples/tree/master/hello_network)
-example and configuring the QEMU command line `-net` directives for your
-environment.
+example:
+
+    $ git clone https://github.com/nerves-project/nerves-examples.git
+
+    $ cd nerves-examples/hello_network
+
+    $ NERVES_TARGET=qemu_arm mix deps.get
+
+    $ NERVES_TARGET=qemu_arm mix firmware
+
+    $ fwup -a -d _images/qemu_arm/hello_network.img -i _images/qemu_arm/hello_network.fw -t complete
+
+    $ sudo qemu-system-arm -M vexpress-a9 -smp 1 -m 256                    \
+        -kernel _build/qemu_arm/dev/nerves/system/images/zImage            \
+        -dtb _build/qemu_arm/dev/nerves/system/images/vexpress-v2p-ca9.dtb \
+        -drive file=_images/qemu_arm/hello_network.img,if=sd,format=raw    \
+        -append "console=ttyAMA0,115200 root=/dev/mmcblk0p2" -serial stdio \
+        -net nic,model=lan9118                                             \
+        -net tap,ifname=tap0,script=qemu-ifup.sh,downscript=qemu-ifdown.sh
+
+Once booted up into the IEX console, you can verify that network connectivity and
+DNS name resolution works by typing in:
+
+    iex(1)> HelloNetwork.test_dns
+    {:ok,
+     {:hostent, 'nerves-project.org', [], :inet, 4,
+      [{192, 30, 252, 154}, {192, 30, 252, 153}]}}
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,16 @@ If you know how to improve this, please contribute a README improvement.)
 
 #### 4. DHCP configuration
 
-**TODO**
+As a last prerequisite, let's set up
+[Dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html) to handle DHCP
+requests on the `bridge1` interface. Dnsmasq is available via both Homebrew
+and MacPorts. The following depicts installation from Homebrew:
+
+    $ brew install dnsmasq
+
+    $ curl -OL https://github.com/nerves-project/nerves_system_qemu_arm/raw/develop/qemu-dnsmasq.conf
+
+    $ dnsmasq --conf-file=qemu-dnsmasq.conf  # daemonizes into the background
 
 ### Hello, Network!
 
@@ -148,6 +157,8 @@ DNS name resolution works by typing in:
     {:ok,
      {:hostent, 'nerves-project.org', [], :inet, 4,
       [{192, 30, 252, 154}, {192, 30, 252, 153}]}}
+
+[![Screenshot](http://i.imgur.com/tjcVfHdh.jpg)](http://i.imgur.com/tjcVfHd.jpg)
 
 ## Installation
 

--- a/qemu-dnsmasq.conf
+++ b/qemu-dnsmasq.conf
@@ -1,0 +1,6 @@
+interface=bridge1
+bind-interfaces
+dhcp-range=192.168.78.2,192.168.78.99,12h
+no-resolv
+server=8.8.8.8
+server=8.8.4.4

--- a/qemu-ifdown.sh
+++ b/qemu-ifdown.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+case $OSTYPE in
+  darwin*)
+    ifconfig bridge1 deletem "$1"
+    ;;
+esac

--- a/qemu-ifup.sh
+++ b/qemu-ifup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+case $OSTYPE in
+  darwin*)
+    ifconfig bridge1 addm "$1"
+    ;;
+esac

--- a/qemu-pf.conf
+++ b/qemu-pf.conf
@@ -1,0 +1,2 @@
+# pfctl(8) NAT configuration for QEMU on OS X.
+nat on en0 from bridge1:network to any -> (en0)


### PR DESCRIPTION
It's not exactly trivial, but it _is_ possible to get Nerves under QEMU on OS X to talk to the network:

[![Screenshot](http://i.imgur.com/tjcVfHdh.jpg)](http://i.imgur.com/tjcVfHd.jpg)

https://github.com/bendiken/nerves_system_qemu_arm/tree/howto-networking#networking

A remaining deficiency of networking under QEMU (other than the overall complexity of the procedure) is that DNS resolution in the VM doesn't seem to work unless one explicitly specifies the nameservers to be used directly to Erlang's [inet_res](http://erlang.org/doc/man/inet_res.html):

```
iex(1)> :inet_res.lookup('nerves-project.org', :in, :a)
[]
iex(2)> :inet_res.lookup('nerves-project.org', :in, :a, [nameservers: [{{8,8,8,8}, 53}]])
[{192, 30, 252, 153}, {192, 30, 252, 154}]
```

That doesn't seem like it is a QEMU-specific problem, necessarily, but I haven't investigated further in [nerves_networking](https://github.com/nerves-project/nerves_networking) as yet. The reason I don't think the DNS issue has to do (only) with the QEMU configuration is that even when I hacked the [HelloNetwork](https://github.com/nerves-project/nerves-examples/tree/master/hello_network) example to use static IPv4 configuration with Google's DNS servers hardcoded in, the problem remained.

Other than that caveat, everything seems to work as it should. Remote IEx shell sessions to the QEMU virtual machine work great, for example.

Kudos to @mikegogulski who first figured this out for Linux, based on which I adapted to OS X. (Ubuntu instructions will be forthcoming in a follow-up pull request once they've been cleaned up and tested from scratch on a new brand new 16.04 install.)
